### PR TITLE
Add redirection to chat rooms if user is already logged in on LoginPage

### DIFF
--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,11 +1,19 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { setCurrentUser } from '../utils/localStorage'
+import { getCurrentUser, setCurrentUser } from '../utils/localStorage'
 import '../styles/LoginPage.css'
 
 const LoginPage = () => {
   const [username, setUsername] = useState('') // État pour stocker le nom d'utilisateur
   const navigate = useNavigate() // Hook pour rediriger après connexion
+
+  // Vérifie si l'utilisateur est déjà connecté
+  useEffect(() => {
+    const currentUser = getCurrentUser()
+    if (currentUser) {
+      navigate('/chat-rooms') // Redirige vers les salons
+    }
+  }, [navigate])
 
   // Soumission du formulaire
   const handleLogin = (e) => {


### PR DESCRIPTION
- Ajout d'une redirection conditionnelle dans LoginPage :
  - Si un utilisateur est connecté, il est automatiquement redirigé vers /chat-rooms.
  - Sinon, l'utilisateur reste sur la page de connexion.
- Utilisation de useEffect pour vérifier l'état de connexion via getCurrentUser.